### PR TITLE
Removing `cursor: pointer` from `.event` to prevent mis-clicks

### DIFF
--- a/source/assets/stylesheets/_global.css.scss
+++ b/source/assets/stylesheets/_global.css.scss
@@ -37,7 +37,6 @@ body {
   border-radius: 3px;
   box-sizing: border-box;
   clear: both;
-  cursor: pointer;
   font-size: 18px;
   line-height: 17px;
   min-height: 42px;


### PR DESCRIPTION
Noticed that the `li.entry` had a `cursor: pointer` attribute when only the link inside of it was actually clickable. Now you still have the highlight on hover and can click on the link itself.
