### PR TITLE
add Nomad Loot to gear

### DIFF
--- a/data/gear.yml
+++ b/data/gear.yml
@@ -14,3 +14,6 @@
 -
   - "http://nomadforum.io/t/do-you-travel-with-a-laptop-stand/987"
   - "Nomad friendly laptop stands"
+-
+  - "https://nomadloot.com"
+  - "Nomad Loot: The Best Travel Gear for Digital Nomads"


### PR DESCRIPTION
Feel free to change the title.
The goal with Nomad Loot is to list the best digital nomad gear for every category.
We add a few items every week and the goal is to make it a useful resource for
digital nomads.
